### PR TITLE
Add automatic https certificate generation with letscrypt.

### DIFF
--- a/cfg/conf.yaml
+++ b/cfg/conf.yaml
@@ -81,7 +81,7 @@ groups:
 - [xen,        '^(h|m|n)$',                                        {services: [xen]}]
 - [megaraid,   '^(h|m|n|r|t)$',                                    {services: [megaraid]}]
 - [http,       '^(anytask|school|hackerdom|kvkt|ructf)-back$',     {services: [http]}]
-- [https,      '^(redmine|ructf)-back$                             {services: [https]}]
+- [https,      '^(redmine|ructf)-back$',                           {services: [https]}]
 - [uzers_unix, '^(h|m|mm|n|p|ts|it|it2)$',                         {services: [exim_default, autoupdate]}]
 - [auto_vms,   '^((irc|school|ructf|kvkt)-back|shannon)$',         {services: [exim_default, autoupdate]}]
 

--- a/cfg/conf.yaml
+++ b/cfg/conf.yaml
@@ -81,7 +81,7 @@ groups:
 - [xen,        '^(h|m|n)$',                                        {services: [xen]}]
 - [megaraid,   '^(h|m|n|r|t)$',                                    {services: [megaraid]}]
 - [http,       '^(anytask|school|hackerdom|kvkt|ructf)-back$',     {services: [http]}]
-- [https,      '^redmine-back$',                                   {services: [https]}]
+- [https,      '^(redmine|ructf)-back$                             {services: [https]}]
 - [uzers_unix, '^(h|m|mm|n|p|ts|it|it2)$',                         {services: [exim_default, autoupdate]}]
 - [auto_vms,   '^((irc|school|ructf|kvkt)-back|shannon)$',         {services: [exim_default, autoupdate]}]
 
@@ -211,7 +211,7 @@ hosts:
 - [[markov, m],                9.3,    [0015176b9b3c, 0015176b9b3d], {
                                         tcp_fwd: {3260: 3260},
                                         fb: [10.229, '11.240', '12.250', '194.226.244.126'],
-                                        backend_for: m.fb.urgu.org,
+                                        backend_for: [m.fb.urgu.org],
                                         services: [http, slurm-client],
                                         ups: hlu,
                                         admin: uzer,
@@ -221,7 +221,7 @@ hosts:
 - [[hamming, h],               9.5,    [000423d6896e, 000423d6896f], {
                                         tcp_fwd: {3261: 3261},
                                         fb: [10.228],
-                                        backend_for: h.fb.urgu.org,
+                                        backend_for: [h.fb.urgu.org],
                                         services: [http, slurm-client],
                                         ups: bfu,
                                         admin: uzer,
@@ -309,7 +309,7 @@ hosts:
                                                   hadoop_rack: runc,
                                                   disk: 'ata-ST380815AS_????????'}]
 - [ irc-back,             10.222,  001851bcb7a7, {tcp_fwd: {6665: 6665, 6666: 6666, 6667: 6667, 6668: 6668, 6669: 6669},
-                                                  backend_for: irclog.hackerdom.ru, admin: and}]
+                                                  backend_for: [irclog.hackerdom.ru], admin: and}]
 - [ dc3.runc,             10.223,  00163a34f84d, {tcp_fwd: {636: 636, 88: 88}, admin: uzer}]
 - [ asus2,                10.224,  14dae9c9a629, {services: [nvidia]}]
 #   ritchie-fastbone      10.225
@@ -374,7 +374,8 @@ hosts:
                                                                 ructf.info, www.ructf.info,
                                                                 ructf.net, www.ructf.net,
                                                                 ructfe.ru, www.ructfe.ru,
-                                                                ructfe.org, www.ructfe.org]}]
+                                                                ructfe.org, www.ructfe.org],
+                                                  generate_cert: 1}]
 - [ image64-test,         10.251, [000c29ad7768, 000c29ad7769], {services: [slurm-node]}]
 - [ image64,              10.252,  000c29ad7767, {services: [slurm-client, ad]}]
 #   main-switch           10.253

--- a/cfg/http_back.template
+++ b/cfg/http_back.template
@@ -1,40 +1,28 @@
 {%- for host in state.hosts %}
 {%- if ('http' in host.services or 'https' in host.services) and 'backend_for' in host.props -%}
-{%- if host.props['backend_for'] is string %}
-server {
-    server_name {{ host.props['backend_for'] }};
-    {% if 'http' in host.services %}
-    listen 80;
-    {% else %}
-    listen              443 ssl;
-    ssl_certificate     {{ keypath }}/{{ host.props['backend_for'] }}.crt;
-    ssl_certificate_key {{ keypath }}/{{ host.props['backend_for'] }}.key;
-    {% endif %}
-
-    access_log  /var/log/nginx/{{ host.props['backend_for'].replace('*','_') }}.access.log;
-    error_log   /var/log/nginx/{{ host.props['backend_for'].replace('*','_') }}.error.log;
-
-    proxy_set_header    X-Forwarded-For $remote_addr;
-    proxy_set_header    Host            $host;
-
-    location / {
-        {% if 'http' in host.services %}
-        proxy_pass      http://{{ host.addr }};
-        {% else %}
-        proxy_pass      https://{{ host.addr }};
-        {% endif %}
-    }
-}
-{% else %}
 {% for hostname in host.props['backend_for'] %}
 server {
     server_name {{ hostname }};
     {% if 'http' in host.services %}
     listen 80;
-    {% else %}
-    listen              443 ssl;
-    ssl_certificate     {{ keypath }}/{{ hostname }}.crt;
-    ssl_certificate_key {{ keypath }}/{{ hostname }}.key;
+    {% endif %}
+
+    {% if 'https' in host.services %}
+        listen              443 ssl;
+        {% if host.props['generate_cert'] %}
+        ssl_certificate     /etc/letsencrypt/live/{{ hostname }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ hostname }}/privkey.pem;
+        {% else %}
+        ssl_certificate     {{ keypath }}/{{ host.props['backend_for'] }}.crt;
+        ssl_certificate_key {{ keypath }}/{{ host.props['backend_for'] }}.key;
+        {% endif %}
+    {% endif %}
+
+    {% if host.props['generate_cert'] %}
+    location /.well-known {
+        root /var/www;
+        autoindex off;
+    }
     {% endif %}
 
     access_log  /var/log/nginx/{{ hostname.replace('*','_') }}.access.log;
@@ -52,6 +40,5 @@ server {
     }
 }
 {% endfor %}
-{% endif -%}
 {% endif -%}
 {% endfor -%}

--- a/do.sh
+++ b/do.sh
@@ -14,6 +14,11 @@ export CFG=$CFGDIR/conf.yaml
 ROUTER_HOST=dijkstra.urgu.org
 ROUTER_IP=194.226.244.126
 
+CERTBOT_DIR="/opt/certbot"
+CERTBOT=$CERTBOT_DIR/certbot-auto
+CERTBOT_URL="https://dl.eff.org/certbot-auto"
+CERTBOT_DEFAULT_PARAMS=" certonly --webroot --non-interactive --agree-tos --email znick@znick.ru -w /var/www "
+
 cmp_files() {
     set +e; cmp -s $1 $2; local rv=$?; set -e
     return $rv
@@ -404,6 +409,22 @@ gen_keys_images() {
             umount "$MP"
         fi
     done
+}
+
+download_certbot() {
+    mkdir -p "$CERTBOT_DIR"
+    [ -x "$CERTBOT" ] || wget -O "$CERTBOT" "$CERTBOT_URL"
+    chmod +x "$CERTBOT"
+}
+
+gen_letscrypt_certs() {
+    local domains=$($MAIN generate_cert_domains)
+
+    download_certbot
+    for domain in $domains; do
+        $CERTBOT $CERTBOT_DEFAULT_PARAMS -d $domain
+    done
+    service nginx reload
 }
 
 mkdir -p $DATA

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -3,6 +3,7 @@ import dhcp
 import dns
 import http
 import iptables
+import letscrypt
 import mrtg
 import nagios
 import puppet

--- a/gen/http.py
+++ b/gen/http.py
@@ -1,4 +1,5 @@
 import jinja2
+from letscrypt import filter_state
 from cmd import add_cmd
 
 @add_cmd('ext_http', True, 1)
@@ -7,6 +8,7 @@ def gen_ext_http(state, template, keypath):
 
 @add_cmd('http_back', True, 1)
 def gen_http_back(state, template, keypath):
+    state = filter_state(state)
     return jinja2.Template(template).render(state=state, keypath=keypath)
 
 @add_cmd('https', False, 0)

--- a/gen/letscrypt.py
+++ b/gen/letscrypt.py
@@ -1,0 +1,33 @@
+import os
+from cmd import add_cmd
+import sys
+
+KEYPREFIX = "/etc/letsencrypt/live/"
+
+def get(state):
+    for host in state.hosts:
+        if 'generate_cert' not in host.props or 'backend_for' not in host.props:
+            continue
+
+        yield host
+
+def filter_state(state):
+    for host in state.hosts:
+        if 'generate_cert' not in host.props:
+            continue
+
+        for domain in host.props.get('backend_for', []):
+            keydir = os.path.join(KEYPREFIX, domain)
+
+            if not os.path.exists(keydir):
+                if 'https' in host.services:
+                    host.services.remove('https')
+
+    return state
+
+@add_cmd('generate_cert_domains', False, 0)
+def gen(state):
+    hostnames = []
+    for host in get(state):
+        hostnames.extend(host.props['backend_for'])
+    return "\n".join(hostnames)


### PR DESCRIPTION
Это предварительный pull request. Некоторые вещи я просто не знаю как правильно делать в cfg, поэтому, надеюсь, что ты подскажешь.

Особенно мне не нравится решение с filter_state в gen_http. Это как раз нужно для корректной обработки ситуации, когда сертификата еще нет.

Ну и там наверняка взорвется сайт ructf если это все накатить, поэтому нужно видимо как-то выбрать время и сесть вместе это сделать.
